### PR TITLE
add support for connecting to puppetdb with http basic auth

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+---
+ignored:
+  # disable pinning apk package versions
+  - DL3018

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@ WORKDIR /go/src/github.com/camptocamp/prometheus-puppetdb-exporter
 COPY . .
 RUN make prometheus-puppetdb-exporter
 
-FROM scratch
+FROM alpine:3
+RUN apk --update --no-cache add \
+    ca-certificates \
+    && rm -rf /root/.cache
 COPY --from=builder /go/src/github.com/camptocamp/prometheus-puppetdb-exporter/prometheus-puppetdb-exporter /
 ENTRYPOINT ["/prometheus-puppetdb-exporter"]
 CMD [""]

--- a/internal/exporter/exporter.go
+++ b/internal/exporter/exporter.go
@@ -25,7 +25,7 @@ var (
 )
 
 // NewPuppetDBExporter returns a new exporter of PuppetDB metrics.
-func NewPuppetDBExporter(url, certPath, caPath, keyPath string, sslSkipVerify bool, categories map[string]struct{}) (e *Exporter, err error) {
+func NewPuppetDBExporter(url, certPath, caPath, keyPath string, sslSkipVerify bool, authType, authUser, authPass string, categories map[string]struct{}) (e *Exporter, err error) {
 	e = &Exporter{
 		namespace: "puppetdb",
 	}
@@ -36,6 +36,9 @@ func NewPuppetDBExporter(url, certPath, caPath, keyPath string, sslSkipVerify bo
 		CACertPath: caPath,
 		KeyPath:    keyPath,
 		SSLVerify:  sslSkipVerify,
+		AuthType:   authType,
+		AuthUser:   authUser,
+		AuthPass:   authPass,
 	}
 
 	e.client, err = puppetdb.NewClient(opts)

--- a/internal/puppetdb/puppetdb.go
+++ b/internal/puppetdb/puppetdb.go
@@ -139,6 +139,12 @@ func (p *PuppetDB) get(endpoint string, query string, object interface{}) (err e
 		err = fmt.Errorf("failed to read response: %s", err)
 		return
 	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("Non-OK HTTP status: %d\nResponse: %s", resp.StatusCode, string(body))
+		return
+	}
+
 	err = json.Unmarshal(body, object)
 	if err != nil {
 		err = fmt.Errorf("failed to unmarshal: %s", err)

--- a/internal/puppetdb/puppetdb.go
+++ b/internal/puppetdb/puppetdb.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
+	log "github.com/sirupsen/logrus"
 )
 
 // PuppetDB stores informations used to connect to a PuppetDB
@@ -122,11 +124,15 @@ func (p *PuppetDB) get(endpoint string, query string, object interface{}) (err e
 	} else {
 		myurl = fmt.Sprintf("%s/v4/%s?query=%s", base, endpoint, url.QueryEscape(query))
 	}
+
 	req, err := http.NewRequest("GET", myurl, strings.NewReader(""))
 	if err != nil {
 		err = fmt.Errorf("failed to build request: %s", err)
 		return
 	}
+
+	log.Debugln("req:", req)
+
 	resp, err := p.client.Do(req)
 	if err != nil {
 		err = fmt.Errorf("failed to call API: %s", err)

--- a/main.go
+++ b/main.go
@@ -29,6 +29,9 @@ type Config struct {
 	Verbose        bool   `long:"verbose" description:"Enable debug mode" env:"PUPPETDB_VERBOSE"`
 	UnreportedNode string `long:"unreported-node" description:"Tag nodes as unreported if the latest report is older than the defined duration." env:"PUPPETDB_UNREPORTED_NODE" default:"2h"`
 	Categories     string `long:"categories" description:"Report metrics categories to scrape." env:"REPORT_METRICS_CATEGORIES" default:"resources,time,changes,events"`
+	BasicAuth      bool   `long:"basic-auth" description:"Enable http basic auth" env:"PUPPETDB_BASIC_AUTH"`
+	AuthUser       string `long:"user" description:"Http basic auth user" env:"PUPPETDB_USER"`
+	AuthPass       string `long:"pass" description:"Http basic auth password" env:"PUPPETDB_PASS"`
 }
 
 var (
@@ -76,7 +79,11 @@ func main() {
 	for _, category := range cats {
 		categories[category] = struct{}{}
 	}
-	exp, err := exporter.NewPuppetDBExporter(c.PuppetDBUrl, c.CertFile, c.CACertFile, c.KeyFile, c.SSLSkipVerify, categories)
+	authType := "x509"
+	if c.BasicAuth {
+		authType = "basic"
+	}
+	exp, err := exporter.NewPuppetDBExporter(c.PuppetDBUrl, c.CertFile, c.CACertFile, c.KeyFile, c.SSLSkipVerify, authType, c.AuthUser, c.AuthPass, categories)
 	if err != nil {
 		log.Fatalf("failed to initialize exporter: %s", err)
 	}


### PR DESCRIPTION
This allows the exporter to deployed independently from puppetdb and without the ability to write to puppetdb, as is the default when authenticating with a cert signed by the puppetdb/puppetserver CA.
